### PR TITLE
Integration tests: leverage new occam feature

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.18
 
 require (
 	github.com/BurntSushi/toml v1.2.1
-	github.com/docker/docker v20.10.23+incompatible
 	github.com/onsi/gomega v1.26.0
 	github.com/paketo-buildpacks/occam v0.15.0
 	github.com/paketo-buildpacks/packit/v2 v2.8.0
@@ -22,6 +21,7 @@ require (
 	github.com/containerd/cgroups v1.0.4 // indirect
 	github.com/containerd/containerd v1.6.12 // indirect
 	github.com/docker/distribution v2.8.1+incompatible // indirect
+	github.com/docker/docker v20.10.23+incompatible // indirect
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.1 // indirect

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -1,7 +1,6 @@
 package integration_test
 
 import (
-	gocontext "context"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -9,8 +8,6 @@ import (
 	"time"
 
 	"github.com/BurntSushi/toml"
-	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/client"
 	"github.com/onsi/gomega/format"
 	"github.com/paketo-buildpacks/occam"
 	"github.com/sclevine/spec"
@@ -36,6 +33,7 @@ var (
 )
 
 func TestIntegration(t *testing.T) {
+	docker := occam.NewDocker()
 	Expect := NewWithT(t).Expect
 
 	format.MaxLength = 0
@@ -91,9 +89,5 @@ func TestIntegration(t *testing.T) {
 	// We have validated that the following code runs even if the tests fail (though not if they panic)
 
 	// Clean up redis image
-	dockerClient, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
-	Expect(err).NotTo(HaveOccurred())
-
-	_, err = dockerClient.ImageRemove(gocontext.Background(), "redis:latest", types.ImageRemoveOptions{Force: true})
-	Expect(err).NotTo(HaveOccurred())
+	Expect(docker.Image.Remove.WithForce().Execute("redis:latest")).To(Succeed())
 }


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Small change to integration tests to leverage new occam image removal with force.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
